### PR TITLE
Fix Mac Addr attributes for Wan Sensor

### DIFF
--- a/custom_components/openwrt/sensor.py
+++ b/custom_components/openwrt/sensor.py
@@ -267,7 +267,7 @@ class WanRxTxSensor(OpenWrtSensor):
 
     @property
     def extra_state_attributes(self):
-        return dict(mac=self._data.get("macaddr"), speed=self._data.get("speed"))
+        return dict(mac=self._data.get("mac"), speed=self._data.get("speed"))
 
     @property
     def state_class(self):


### PR DESCRIPTION
The Mac address appears in the sensor attributes undefined because it is not read correctly from the retrieved properties. When the ubus call is made the property is macaddr, but this property is stored in mac and not in macaddr back.