### PR TITLE
Correct RX and TX units

### DIFF
--- a/custom_components/openwrt/sensor.py
+++ b/custom_components/openwrt/sensor.py
@@ -267,7 +267,7 @@ class WanRxTxSensor(OpenWrtSensor):
 
     @property
     def extra_state_attributes(self):
-        return dict(mac=self._data.get("macaddr"), speed=self._data.get("speed"))
+        return dict(mac=self._data.get("mac"), speed=self._data.get("speed"))
 
     @property
     def state_class(self):

--- a/custom_components/openwrt/sensor.py
+++ b/custom_components/openwrt/sensor.py
@@ -4,7 +4,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityCategory
-
+from homeassistant.components.sensor import SensorDeviceClass
 
 import logging
 
@@ -243,7 +243,8 @@ class WanRxTxSensor(OpenWrtSensor):
         self._code = code
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
         self._attr_icon = "mdi:download-network" if code == "rx" else "mdi:upload-network"
-        self._attr_native_unit_of_measurement = "bytes"
+        self._attr_device_class = SensorDeviceClass.DATA_SIZE
+        self._attr_native_unit_of_measurement = "B"
 
     @property 
     def _data(self):


### PR DESCRIPTION
The device class attribute associated with the RX and TX sensors is set and the native unit of measurement is correctly specified so that by modifying the sensor configuration from the Home Assistant interface the displayed unit can be changed from Bytes to Gigabytes, for example.