### PR TITLE
Fix crash when wifi interface is down

### DIFF
--- a/custom_components/openwrt/coordinator.py
+++ b/custom_components/openwrt/coordinator.py
@@ -54,6 +54,8 @@ class DeviceCoordinator:
                 if item.get('disabled', False):
                     continue
                 for iface in item['interfaces']:
+                    if 'ifname' not in iface:
+                        continue
                     conf = dict(ifname=iface['ifname'],
                                 network=iface['config']['network'][0])
                     if iface['config']['mode'] == 'ap':


### PR DESCRIPTION
Fix #29.

This will prevent the error from happening. Obviously, Wifi metrics disappear in this case (because we do not know the interface names). Unfortunately, metrics do not seem to reappear automatically when we reload after starting the wifi interface. Not sure why this is the case but still this is better than the status quo.