### PR TITLE
fix mesh 'NoneType' if confflow empty

### DIFF
--- a/custom_components/openwrt/coordinator.py
+++ b/custom_components/openwrt/coordinator.py
@@ -74,6 +74,9 @@ class DeviceCoordinator:
         result = []
         for _, device in self._all_devices.items():
             data = device.coordinator.data
+            if not data or 'mesh' not in data or not data['mesh']:
+                _LOGGER.warning(f"Missing or invalid 'mesh' data for device: {device}")
+                continue
             for _, mesh in data['mesh'].items():
                 if mesh['id'] == mesh_id:
                     result.append(mesh['mac'])


### PR DESCRIPTION
After updating to V0.2.0 I noticed the following error: 

```
Device [AX3600] async_update_data error: 'NoneType' object is not subscriptable
Traceback (most recent call last):
  File "/config/custom_components/openwrt/coordinator.py", line 330, in async_update_data
    result['mesh'] = await self.update_mesh(wireless_config['mesh'])
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/config/custom_components/openwrt/coordinator.py", line 105, in update_mesh
    for mac in self.find_mesh_peers(conf['mesh_id']):
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/config/custom_components/openwrt/coordinator.py", line 77, in find_mesh_peers
    for _, mesh in data['mesh'].items():
                   ~~~~^^^^^^^^
TypeError: 'NoneType' object is not subscriptable
```

This PR fixes this. The reason is that I left mesh empty at config flow, but I am using mesh. 